### PR TITLE
like and subscribe track

### DIFF
--- a/src/middleware/optionalAuth.middleware.js
+++ b/src/middleware/optionalAuth.middleware.js
@@ -1,0 +1,31 @@
+
+import jwt from "jsonwebtoken";
+import { User } from "../models/user.model.js";
+
+
+const optionalAuth = async (req, _, next) => {
+  try {
+    const token =
+      req.cookies?.accessToken ||
+      req.header("Authorization")?.replace("Bearer ", "");
+
+    if (!token) {
+      req.user = null; 
+      return next();
+    }
+
+    const decodedToken = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+    const user = await User.findById(decodedToken?._id).select(
+      "-password -refreshToken"
+    );
+
+    req.user = user || null;
+  } catch (error) {
+    // Token is invalid → treat as guest
+    req.user = null;
+  }
+
+  next();
+};
+
+export { optionalAuth };

--- a/src/routes/video.routes.js
+++ b/src/routes/video.routes.js
@@ -10,10 +10,11 @@ import {
 } from "../controllers/video.controller.js"
 import {verifyJWT} from "../middleware/auth.middleware.js"
 import {upload} from "../middleware/multer.middleware.js"
+import { optionalAuth } from '../middleware/optionalAuth.middleware.js';
 
 const router = Router();
 router.route("/").get(getAllVideos);
-router.route("/:videoId").get(getVideoById);
+router.route("/:videoId").get(optionalAuth,getVideoById);
 router.route("/views/:videoId").patch(increaseVideoViews);
 router.use(verifyJWT); // Apply verifyJWT middleware to all routes in this file
 


### PR DESCRIPTION
✨ Pull Request: like and subscribe track
🔧 Summary of Changes:
This PR introduces support for authenticated and guest access to video detail routes, along with improvements in subscription and like logic.

✅ Features Added:
✅ Implemented optionalAuth.js middleware to gracefully handle guest vs logged-in users

✅ Applied optionalAuth to GET /video/:id route for better UX:

Logged-in users now correctly receive isSubscribed and isLiked flags

Guest users can still view videos without triggering auth errors

✅ Updated getVideoById controller to check for req.user safely

✅ Refactored console logs for debugging token-related flow

✅ Minor improvements in route readability and middleware design

🐛 Bug Fixes:
🐞 Fixed isSubscribed always being false due to req.user being undefined

🐞 Resolved silent failures in console due to missing auth in public route

🧪 How to Test:
Hit GET /video/:videoId in Postman or frontend

As guest → no crash, video loads, isSubscribed = false

As logged-in user → isSubscribed reflects actual subscription

Test routes that use verifyJWT to ensure stricter access still works

📌 Notes:
This PR does not break any protected routes

Next step could be to apply optionalAuth to GET /videos and channel views